### PR TITLE
Wrap delete statements in tmp table select

### DIFF
--- a/scripts/category.sql
+++ b/scripts/category.sql
@@ -1,5 +1,7 @@
 -- Enable `entity_id` column for catalog category entity
-DELETE FROM catalog_category_entity WHERE row_id NOT IN (SELECT MAX(row_id) FROM catalog_category_entity GROUP BY entity_id);
+DELETE FROM catalog_category_entity WHERE row_id NOT IN (
+    SELECT tmp_category.row_id FROM (SELECT MAX(row_id) AS row_id FROM catalog_category_entity GROUP BY entity_id) tmp_category
+);
 
 ALTER TABLE `catalog_category_entity_datetime`
     ADD COLUMN `entity_id` INT(10) UNSIGNED NOT NULL DEFAULT 0 COMMENT 'Entity ID';

--- a/scripts/product.sql
+++ b/scripts/product.sql
@@ -297,7 +297,9 @@ ALTER TABLE `catalog_product_bundle_selection_price`
 
 -- Force Clean Duplicates (should already be cleaned by the latest active version, see upper)
 
-DELETE FROM catalog_product_entity WHERE row_id NOT IN (SELECT MAX(row_id) FROM catalog_product_entity  GROUP BY entity_id);
+DELETE FROM catalog_product_entity WHERE row_id NOT IN (
+    SELECT tmp_product.row_id FROM (SELECT MAX(row_id) AS row_id FROM catalog_product_entity  GROUP BY entity_id) tmp_product
+);
 
 -- Clean Invalid Entities (May occurs in some cases)
 


### PR DESCRIPTION
MySQL won't allow a deletion of records when selecting the same table. This will give the "You can't specify target table for update in FROM clause" error. By wrapping the select statement within an alias wou can make mysql create a temp table. See also https://stackoverflow.com/a/18389545 